### PR TITLE
fixed issue with unused close function passed to node stream constructor

### DIFF
--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -43,24 +43,29 @@ module.exports = function factory (userOptions) {
 
   // This stream is the one returned to psock.js.
   const outputStream = stream.Writable({
-    close () { socket.end() },
     write (data, encoding, callback) {
       socket.write(data)
       callback()
     }
   })
 
+  outputStream.close = function () {
+    socket.unref()
+    process.stdin.unpipe(inputStream, { end: true })
+    inputStream.unpipe(outputStream, { end: true })
+  }
+
   // begin: connection handlers
   function connect (cb) {
     if (connecting) return
     connecting = true
     socket = net.createConnection(
-      {host: options.address, port: options.port},
+      { host: options.address, port: options.port },
       () => {
         connecting = false
         connected = true
         if (cb) cb(null, connected)
-        inputStream.pipe(outputStream, {end: false})
+        inputStream.pipe(outputStream, { end: false })
         inputStream.resume()
       }
     )

--- a/lib/UdpConnection.js
+++ b/lib/UdpConnection.js
@@ -14,13 +14,17 @@ module.exports = function factory (userOptions) {
   const socket = dgram.createSocket('udp4')
 
   const writableStream = new stream.Writable({
-    close () { socket.close() },
     write (data, encoding, callback) {
       socket.send(data, 0, data.length, options.port, options.address)
       callback()
     }
   })
 
-  process.stdin.pipe(writableStream, {end: false})
+  writableStream.close = function () {
+    socket.unref()
+    process.stdin.unpipe(writableStream, { end: true })
+  }
+
+  process.stdin.pipe(writableStream, { end: false })
   return writableStream
 }


### PR DESCRIPTION
The close function was ignored by the constructor of Writable Stream. It was changed to be a public method of the output stream for both TCP and UDP connections. Also, it was changed to just delete all references for all callbacks from socket to prevent loose of messages that have been sent.