### PR TITLE
fix: psock.js becomes the only entrypoint for both CLI and library usage mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-'use strict'
-
-const path = require('path')
-const fs = require('fs')
-const realPath = fs.realpathSync(__dirname)
-const script = path.join(realPath, 'psock.js')
-
-require(script.toString())

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cov": "nyc mocha --ui qunit -R dot test"
   },
   "bin": {
-    "pino-socket": "./app.js"
+    "pino-socket": "./psock.js"
   },
   "keywords": [
     "pino",

--- a/psock.js
+++ b/psock.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict'
 
 const path = require('path')


### PR DESCRIPTION
unit tests seemed irrelevant to me for this case