### PR TITLE
resolves #69 Backoff strategy should be instantiated once and reset when the connection is established again

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,15 +27,27 @@ const transport = pino.transport({
   target: 'pino-socket',
   options: {
     address: '10.10.10.5',
-    port: 5000.
+    port: 5000,
     mode: 'tcp'
   }
 })
 pino(transport)
 ```
 
-All options are described further below.
-Note that the `echo` option is disabled within this usage.
+### Options
+
+| Name              | Description                                                                                                                                               |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `unixsocket`      | The unix socket path for the destination. Default: `&#8203;`.                                                                                             |
+| `address`         | The host address to connect to. Default: `127.0.0.1`.                                                                                                     |
+| `port`            | The host port to connect to. Default: `514`.                                                                                                              |
+| `mode`            | Either `tcp` or `udp`. Default: `udp`.                                                                                                                    |
+| `secure`          | Enable secure (TLS) connection. Default: false.                                                                                                           |
+| `noverify`        | Allow connection to server with self-signed certificates. Default: false.                                                                                 |
+| `reconnect`       | Enable reconnecting to dropped TCP destinations. Default: false.                                                                                          |
+| `reconnectTries`  | Number of times to attempt reconnection before giving up. Default: `Infinity`                                                                             |
+| `onsocketclose`   | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`          |
+| `backoffstrategy` | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`. |
 
 ## Usage as Pino Legacy Transport
 
@@ -53,27 +65,26 @@ OR
 $ node foo | pino-socket -u /tmp/unix.sock
 ```
 
-## Options
+### CLI Options
 
-+ `--settings` (`-s`): read settings from a JSON file (switches take precedence)
-+ `--unixsocket` (`-u`): the unix socket path for the destination. Default: ``.
++ `--settings` (`-s`): read settings from a JSON file (switches take precedence).
++ `--unixsocket` (`-u`): the unix socket path for the destination. Default: `&#8203;`.
 + `--address` (`-a`): the address for the destination socket. Default: `127.0.0.1`.
 + `--port` (`-p`): the port for the destination socket. Default: `514`.
 + `--mode` (`-m`): either `tcp` or `udp`. Default: `udp`.
 + `--secure` (`-tls`): enable secure (TLS) connection for TCP (only works with `--mode=tcp`).
 + `--noverify` (`-nv`): allow connection to server with self-signed certificates (only works with `--secure`).
-+ `--reconnect` (`-r`): enable reconnecting to dropped TCP destinations. Default: off
-+ `--reconnectTries <n>` (`-t <n>`): set number (`<n>`) of reconnect attempts
-  before giving up. Default: infinite
++ `--reconnect` (`-r`): enable reconnecting to dropped TCP destinations. Default: off.
++ `--reconnectTries <n>` (`-t <n>`): set number (`<n>`) of reconnect attempts before giving up. Default: infinite.
 + `--echo` (`-e`): echo the received messages to stdout. Default: enabled.
 + `--no-echo` (`-ne`): disable echoing received messages to stdout.
 
 [rsyscee]: http://www.rsyslog.com/doc/mmjsonparse.html
 
-### Settings JSON File
+#### Settings JSON File
 
 The `--settings` switch can be used to specify a JSON file that contains
-a hash of settings for the the application. A full settings file is:
+a hash of settings for the application. A full settings file is:
 
 ```json
 {

--- a/Readme.md
+++ b/Readme.md
@@ -46,8 +46,8 @@ pino(transport)
 | `noverify`        | Allow connection to server with self-signed certificates. Default: false.                                                                                 |
 | `reconnect`       | Enable reconnecting to dropped TCP destinations. Default: false.                                                                                          |
 | `reconnectTries`  | Number of times to attempt reconnection before giving up. Default: `Infinity`                                                                             |
-| `onsocketclose`   | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`          |
-| `backoffstrategy` | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`. |
+| `onSocketClose`   | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`          |
+| `backoffStrategy` | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`. |
 
 ## Usage as Pino Legacy Transport
 

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -11,10 +11,10 @@ const { Backoff, FibonacciStrategy } = require('backoff')
  * @prop {boolean} [noverify] Allow connection to server with self-signed certificates. Default: false.
  * @prop {string} [address] The host address to connect to. Default: `127.0.0.1`.
  * @prop {number} [port] The host port to connect to. Default: `514`.
- * @prop {boolean} [reconnect] Whether or not to attempt reconnecting when the connection is dropped. Default: `false`
+ * @prop {boolean} [reconnect] Enable reconnecting to dropped TCP destinations. Default: false.
  * @prop {number} [reconnectTries] Number of times to attempt reconnection before giving up. Default: `Infinity`
  * @prop {string?} [unixsocket] The unix socket path for the destination. Default: ``.
- * @prop {(errorMessage) => void?} [onsocketclose] The callback when the socket is closed. Default: ``.
+ * @prop {(error: Error|null) => void?} [onsocketclose] The callback when the socket is closed. Default: ``.
  * @prop {BackoffStrategy?} [backoffstrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
  */
@@ -34,7 +34,8 @@ module.exports = function factory (userOptions) {
       address: '127.0.0.1',
       port: 514,
       reconnect: false,
-      reconnectTries: Infinity
+      reconnectTries: Infinity,
+      onsocketclose: (socketError) => socketError && process.stderr.write(socketError.message)
     },
     userOptions
   )
@@ -106,7 +107,7 @@ module.exports = function factory (userOptions) {
     disconnect()
     if (hadError) {
       if (options.onsocketclose) {
-        options.onsocketclose(socketError.message)
+        options.onsocketclose(socketError)
       }
     }
     if (options.reconnect) reconnect()

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -3,17 +3,19 @@
 const net = require('net')
 const tls = require('tls')
 const stream = require('stream')
-const backoff = require('backoff')
+const { Backoff, FibonacciStrategy } = require('backoff')
 
 /**
  * @typedef {object} TcpConnectionOptions
- * @prop {boolean} [secure] enable secure (TLS) connection. Default: false.
- * @prop {boolean} [noverify] allow connection to server with self-signed certificates. Default: false.
+ * @prop {boolean} [secure] Enable secure (TLS) connection. Default: false.
+ * @prop {boolean} [noverify] Allow connection to server with self-signed certificates. Default: false.
  * @prop {string} [address] The host address to connect to. Default: `127.0.0.1`.
  * @prop {number} [port] The host port to connect to. Default: `514`.
  * @prop {boolean} [reconnect] Whether or not to attempt reconnecting when the connection is dropped. Default: `false`
  * @prop {number} [reconnectTries] Number of times to attempt reconnection before giving up. Default: `Infinity`
- * @prop {string?} [unixsocket] the unix socket path for the destination. Default: ``.
+ * @prop {string?} [unixsocket] The unix socket path for the destination. Default: ``.
+ * @prop {(errorMessage) => void?} [onsocketclose] The callback when the socket is closed. Default: ``.
+ * @prop {BackoffStrategy?} [backoffstrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
  */
 
@@ -47,6 +49,8 @@ module.exports = function factory (userOptions) {
   let connecting = false
   let socketError = null
 
+  const retryBackoff = createRetryBackoff()
+
   // This stream is the one returned to psock.js.
   const outputStream = stream.Writable({
     autoDestroy: true,
@@ -69,6 +73,7 @@ module.exports = function factory (userOptions) {
       () => {
         connecting = false
         connected = true
+        if (options.reconnect) retryBackoff.reset()
         if (cb) cb(null, connected)
 
         if (sourceStream) {
@@ -92,15 +97,7 @@ module.exports = function factory (userOptions) {
   }
 
   function reconnect () {
-    const retry = backoff.fibonacci()
-    retry.failAfter(options.reconnectTries)
-    retry.on('ready', () => {
-      connect((err) => {
-        if (connected === false) return retry.backoff(err)
-      })
-    })
-    retry.on('fail', (err) => process.stderr.write(`could not reconnect: ${err.message}`))
-    retry.backoff()
+    retryBackoff.backoff()
   }
   // end: connection handlers
 
@@ -108,7 +105,9 @@ module.exports = function factory (userOptions) {
   function closeListener (hadError) {
     disconnect()
     if (hadError) {
-      process.stderr.write(socketError.message)
+      if (options.onsocketclose) {
+        options.onsocketclose(socketError.message)
+      }
     }
     if (options.reconnect) reconnect()
   }
@@ -146,6 +145,20 @@ module.exports = function factory (userOptions) {
     // TODO we must propagate the events from the socket to the outputStream
     outputStream.emit('open')
   })
+
+  function createRetryBackoff () {
+    const retry = new Backoff(options.backoffstrategy ? options.backoffstrategy : new FibonacciStrategy())
+    retry.failAfter(options.reconnectTries)
+    retry.on('ready', () => {
+      connect((err) => {
+        if (connected === false) {
+          return retry.backoff(err)
+        }
+      })
+    })
+    retry.on('fail', (err) => process.stderr.write(`could not reconnect: ${err.message}`))
+    return retry
+  }
 
   return outputStream
 }

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -91,6 +91,7 @@ module.exports = function factory (userOptions) {
     connected = false
     connecting = false
 
+    removeListeners()
     if (sourceStream) {
       sourceStream.pause()
       sourceStream.unpipe(outputStream)
@@ -117,7 +118,6 @@ module.exports = function factory (userOptions) {
 
   function endListener () {
     disconnect()
-    removeListeners()
     if (options.reconnect) reconnect()
   }
 

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -14,8 +14,8 @@ const { Backoff, FibonacciStrategy } = require('backoff')
  * @prop {boolean} [reconnect] Enable reconnecting to dropped TCP destinations. Default: false.
  * @prop {number} [reconnectTries] Number of times to attempt reconnection before giving up. Default: `Infinity`
  * @prop {string?} [unixsocket] The unix socket path for the destination. Default: ``.
- * @prop {(error: Error|null) => void?} [onsocketclose] The callback when the socket is closed. Default: ``.
- * @prop {BackoffStrategy?} [backoffstrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
+ * @prop {(error: Error|null) => void?} [onSocketClose] The callback when the socket is closed. Default: ``.
+ * @prop {BackoffStrategy?} [backoffStrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
  */
 
@@ -35,7 +35,7 @@ module.exports = function factory (userOptions) {
       port: 514,
       reconnect: false,
       reconnectTries: Infinity,
-      onsocketclose: (socketError) => socketError && process.stderr.write(socketError.message)
+      onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message)
     },
     userOptions
   )
@@ -106,8 +106,8 @@ module.exports = function factory (userOptions) {
   function closeListener (hadError) {
     disconnect()
     if (hadError) {
-      if (options.onsocketclose) {
-        options.onsocketclose(socketError)
+      if (options.onSocketClose) {
+        options.onSocketClose(socketError)
       }
     }
     if (options.reconnect) reconnect()
@@ -148,7 +148,7 @@ module.exports = function factory (userOptions) {
   })
 
   function createRetryBackoff () {
-    const retry = new Backoff(options.backoffstrategy ? options.backoffstrategy : new FibonacciStrategy())
+    const retry = new Backoff(options.backoffStrategy ? options.backoffStrategy : new FibonacciStrategy())
     retry.failAfter(options.reconnectTries)
     retry.on('ready', () => {
       connect((err) => {

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -1,0 +1,27 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const TcpConnection = require('../lib/TcpConnection')
+const { ExponentialStrategy } = require('backoff')
+const { expect } = require('chai')
+
+test('tcp backoff', function testTcpBackoff (done) {
+  let retryCount = 0
+  const tcpConnection = TcpConnection({
+    address: '127.0.0.1',
+    port: 0,
+    reconnect: true,
+    backoffstrategy: new ExponentialStrategy({
+      initialDelay: 10,
+      factor: 10 // 10, 100, 1000, 2000...
+    }),
+    onsocketclose: () => {
+      retryCount++
+    }
+  })
+  setTimeout(() => {
+    tcpConnection.end('', 'utf8', () => done())
+    // initial, 10, 100
+    expect(retryCount).to.equal(3)
+  }, 200)
+})

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -11,11 +11,11 @@ test('tcp backoff', function testTcpBackoff (done) {
     address: '127.0.0.1',
     port: 0,
     reconnect: true,
-    backoffstrategy: new ExponentialStrategy({
+    backoffStrategy: new ExponentialStrategy({
       initialDelay: 10,
       factor: 10 // 10, 100, 1000, 2000...
     }),
-    onsocketclose: () => {
+    onSocketClose: () => {
       retryCount++
     }
   })

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -6,22 +6,23 @@ const { ExponentialStrategy } = require('backoff')
 const { expect } = require('chai')
 
 test('tcp backoff', function testTcpBackoff (done) {
-  let retryCount = 0
+  const exponentialStrategy = new ExponentialStrategy({
+    initialDelay: 10,
+    factor: 10 // 10, 100, 1000, 2000...
+  })
   const tcpConnection = TcpConnection({
     address: '127.0.0.1',
     port: 0,
     reconnect: true,
-    backoffStrategy: new ExponentialStrategy({
-      initialDelay: 10,
-      factor: 10 // 10, 100, 1000, 2000...
-    }),
+    backoffStrategy: exponentialStrategy,
     onSocketClose: () => {
-      retryCount++
+      // noop
     }
   })
   setTimeout(() => {
     tcpConnection.end('', 'utf8', () => done())
     // initial, 10, 100
-    expect(retryCount).to.equal(3)
+    const nextBackoffDelay = exponentialStrategy.next()
+    expect(nextBackoffDelay).to.be.gt(100)
   }, 500)
 })

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -23,5 +23,5 @@ test('tcp backoff', function testTcpBackoff (done) {
     tcpConnection.end('', 'utf8', () => done())
     // initial, 10, 100
     expect(retryCount).to.equal(3)
-  }, 200)
+  }, 500)
 })


### PR DESCRIPTION
To make it possible/easier to test, I've introduced two new optional settings:

- `onsocketclose` - a callback function which will be called when the socket is closed (by default, nothing)
- `backoffstrategy` - a backoff strategy (by default `new FibonacciStrategy()` to be backward compatible)

I'm not a big fan of sending error to `stderr` so I've decided to remove `process.stderr.write(socketError.message)`. To be backward compatible we could define a default callback function which does:

```js
(errorMessage)  => process.stderr.write(errorMessage)
```

resolves #69