### PR TITLE
resolves #72 introduce a recovery queue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ pino(transport)
 | `onSocketClose`                | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`.                                                                             |
 | `backoffStrategy`              | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.                                                                     |
 | `recovery`                     | Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.                                     |
-| `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to make space for the newest ones. Default: `1024`.                                                                       |
+| `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.                                                                       |
 | `recoveryQueueSizeCalculation` | Function used to calculate the size of stored items. The item is passed as the first argument and contains a `data` (Buffer) and `encoding` (String) attribute. Default: `(item) => item.data.length + item.encoding.length`. |
 
 ## Usage as Pino Legacy Transport

--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ $ node foo | pino-socket -u /tmp/unix.sock
 + `--echo` (`-e`): echo the received messages to stdout. Default: enabled.
 + `--no-echo` (`-ne`): disable echoing received messages to stdout.
 + `--recovery`: enable recovery mode for TCP (only works with `--mode=tcp`). Default: off.
-+ `--recovery-queue-max-size <n>`: maximum size of items added to the recovery queue. Default: 1024
++ `--recovery-queue-max-size <n>`: maximum size of items (`<n>`) added to the recovery queue. Default: 1024.
 
 [rsyscee]: http://www.rsyslog.com/doc/mmjsonparse.html
 

--- a/Readme.md
+++ b/Readme.md
@@ -36,18 +36,21 @@ pino(transport)
 
 ### Options
 
-| Name              | Description                                                                                                                                               |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `unixsocket`      | The unix socket path for the destination. Default: `&#8203;`.                                                                                             |
-| `address`         | The host address to connect to. Default: `127.0.0.1`.                                                                                                     |
-| `port`            | The host port to connect to. Default: `514`.                                                                                                              |
-| `mode`            | Either `tcp` or `udp`. Default: `udp`.                                                                                                                    |
-| `secure`          | Enable secure (TLS) connection. Default: false.                                                                                                           |
-| `noverify`        | Allow connection to server with self-signed certificates. Default: false.                                                                                 |
-| `reconnect`       | Enable reconnecting to dropped TCP destinations. Default: false.                                                                                          |
-| `reconnectTries`  | Number of times to attempt reconnection before giving up. Default: `Infinity`                                                                             |
-| `onSocketClose`   | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`          |
-| `backoffStrategy` | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`. |
+| Name                           | Description                                                                                                                                                                                                                   |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `address`                      | The host address to connect to. Default: `127.0.0.1`.                                                                                                                                                                         |
+| `port`                         | The host port to connect to. Default: `514`.                                                                                                                                                                                  |
+| `unixsocket`                   | The unix socket path for the destination. Default: `&#8203;`.                                                                                                                                                                 |
+| `mode`                         | Either `tcp` or `udp`. Default: `udp`.                                                                                                                                                                                        |
+| `secure`                       | Enable secure (TLS) connection. Default: false.                                                                                                                                                                               |
+| `noverify`                     | Allow connection to server with self-signed certificates. Default: false.                                                                                                                                                     |
+| `reconnect`                    | Enable reconnecting to dropped TCP destinations. Default: false.                                                                                                                                                              |
+| `reconnectTries`               | Number of times to attempt reconnection before giving up. Default: `Infinity`.                                                                                                                                                |
+| `onSocketClose`                | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`.                                                                             |
+| `backoffStrategy`              | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.                                                                     |
+| `recovery`                     | Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.                                     |
+| `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to make space for the newest ones. Default: `1024`.                                                                       |
+| `recoveryQueueSizeCalculation` | Function used to calculate the size of stored items. The item is passed as the first argument and contains a `data` (Buffer) and `encoding` (String) attribute. Default: `(item) => item.data.length + item.encoding.length`. |
 
 ## Usage as Pino Legacy Transport
 

--- a/Readme.md
+++ b/Readme.md
@@ -49,8 +49,16 @@ pino(transport)
 | `onSocketClose`                | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`.                                                                             |
 | `backoffStrategy`              | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.                                                                     |
 | `recovery`                     | Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.                                     |
-| `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.                                                                       |
+| `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.                                                                                 |
 | `recoveryQueueSizeCalculation` | Function used to calculate the size of stored items. The item is passed as the first argument and contains a `data` (Buffer) and `encoding` (String) attribute. Default: `(item) => item.data.length + item.encoding.length`. |
+
+### Events
+
+| Name    | Description                                                                                                                                                                                                                                                                                          |
+|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `open`  | Emitted when the TCP or UDP connection is established. The listener callback function is invoked with the socket address: ``transport.on('open', (addressInfo) => console.log(`connected to: ${addressInfo.address}:${addressInfo.port} @ ${addressInfo.family}`)``                                  |
+| `error` | Emitted when an error occurs on the TCP or UDP socket. The listener callback function is invoked with an error, the root cause and the socket address: ``transport.on('error', (err) => console.error(`an error occurred: ${err}`)``                                                                 |
+| `close` | Emitted after the TCP or UDP socket is closed. The listener callback function is invoked with a boolean which says if the TCP socket was closed due to a transmission error: ``transport.on('close', (hadError) => console.log(`transport closed ${hadError ? 'with error(s)' : 'without error'}`)`` |
 
 ## Usage as Pino Legacy Transport
 
@@ -81,6 +89,8 @@ $ node foo | pino-socket -u /tmp/unix.sock
 + `--reconnectTries <n>` (`-t <n>`): set number (`<n>`) of reconnect attempts before giving up. Default: infinite.
 + `--echo` (`-e`): echo the received messages to stdout. Default: enabled.
 + `--no-echo` (`-ne`): disable echoing received messages to stdout.
++ `--recovery`: enable recovery mode for TCP (only works with `--mode=tcp`). Default: off.
++ `--recovery-queue-max-size <n>`: maximum size of items added to the recovery queue. Default: 1024
 
 [rsyscee]: http://www.rsyslog.com/doc/mmjsonparse.html
 

--- a/Readme.md
+++ b/Readme.md
@@ -54,11 +54,11 @@ pino(transport)
 
 ### Events
 
-| Name    | Description                                                                                                                                                                                                                                                                                          |
-|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `open`  | Emitted when the TCP or UDP connection is established. The listener callback function is invoked with the socket address: ``transport.on('open', (addressInfo) => console.log(`connected to: ${addressInfo.address}:${addressInfo.port} @ ${addressInfo.family}`)``                                  |
-| `error` | Emitted when an error occurs on the TCP or UDP socket. The listener callback function is invoked with an error, the root cause and the socket address: ``transport.on('error', (err) => console.error(`an error occurred: ${err}`)``                                                                 |
-| `close` | Emitted after the TCP or UDP socket is closed. The listener callback function is invoked with a boolean which says if the TCP socket was closed due to a transmission error: ``transport.on('close', (hadError) => console.log(`transport closed ${hadError ? 'with error(s)' : 'without error'}`)`` |
+| Name    | Callback Signature               | Description                                                                                                                                          |
+|---------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `open`  | `(address: AddressInfo) => void` | Emitted when the TCP or UDP connection is established.                                                                                               |
+| `error` | `(error: Error) => void`         | Emitted when an error occurs on the TCP or UDP socket.                                                                                               |
+| `close` | `(hadError: Boolean) => void`    | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
 
 ## Usage as Pino Legacy Transport
 

--- a/help.txt
+++ b/help.txt
@@ -11,13 +11,14 @@
 
   [36m[1mFlags[22m[39m
   [0m-h  | --help              Display Help
-  -v  | --version           display Version
-  -s  | --settings          read settings from a JSON file (switches take precedence)
-  -a  | --address           the address for the destination socket; default: 127.0.0.1
-  -m  | --mode              the protocol, either 'udp' or 'tcp'; default: 'udp'
-  -p  | --port              the port on the destination socket; default: '514'
-  -u  | --unixsocket        the path of unix socket, default: ''
-  -r  | --reconnect         enable tcp mode reconnecting
-  -t  | --reconnectTries    number of reconnect attempts to make; default 'Inifinity'
-  -ne | --no-echo           disable echoing received messages to stdout
-
+  -v  | --version                   display Version
+  -s  | --settings                  read settings from a JSON file (switches take precedence)
+  -a  | --address                   the address for the destination socket; default: 127.0.0.1
+  -m  | --mode                      the protocol, either 'udp' or 'tcp'; default: 'udp'
+  -p  | --port                      the port on the destination socket; default: '514'
+  -u  | --unixsocket                the path of unix socket; default: ''
+  -r  | --reconnect                 enable tcp mode reconnecting
+  -t  | --reconnectTries            number of reconnect attempts to make; default: 'Inifinity'
+  -ne | --no-echo                   disable echoing received messages to stdout
+      | --recovery                  enable recovery mode
+      | --recovery-queue-max-size   maximum size of items added to the recovery queue; default: 1024

--- a/lib/Queue.js
+++ b/lib/Queue.js
@@ -5,7 +5,7 @@ const { emitWarning } = require('process')
 /**
  * @typedef {object} QueueOptions
  * @prop {number} [maxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `Infinity`
- * @prop {(any) => number?} [sizeCalculation] Function used to calculate the size of stored elements. Default: `element => element.length`.
+ * @prop {(any) => number?} [sizeCalculation] Function used to calculate the size of stored items. Default: `item => item.length`.
  */
 
 /**
@@ -21,25 +21,25 @@ module.exports = class Queue {
    */
   constructor (opts) {
     // The actual queue
-    this.elements = {}
-    // The index of the head element
+    this.items = {}
+    // The index of the head item
     this.head = 0
-    // The index of the tail element
+    // The index of the tail item
     this.tail = 0
     this.calculatedSize = 0
     this.sizes = {}
     this.opts = {
       maxSize: Infinity,
-      sizeCalculation: (element) => element.length,
+      sizeCalculation: (item) => item.length,
       ...opts
     }
   }
 
-  enqueue (element) {
+  enqueue (item) {
     const index = this.tail
-    const size = this.opts.sizeCalculation(element)
+    const size = this.opts.sizeCalculation(item)
     if (size > this.opts.maxSize) {
-      emitWarning(`Unable to enqueue element because element size ${size} is greater than maxSize ${this.opts.maxSize}`)
+      emitWarning(`unable to enqueue item because item size ${size} is greater than maxSize ${this.opts.maxSize}`)
       return
     }
     this.sizes[index] = size
@@ -48,10 +48,10 @@ module.exports = class Queue {
       this.evict()
     }
     this.calculatedSize += size
-    // Add an element on the current tail index
-    this.elements[index] = element
-    // Increase the index of the tail element
-    // So the next elements are added at the end
+    // Add an item on the current tail index
+    this.items[index] = item
+    // Increase the index of the tail item
+    // So the next items are added at the end
     this.tail++
   }
 
@@ -67,16 +67,16 @@ module.exports = class Queue {
   }
 
   dequeue () {
-    const element = this.peek()
-    if (element === undefined) {
-      return element
+    const item = this.peek()
+    if (item === undefined) {
+      return item
     }
     // Delete it
-    delete this.elements[this.head]
+    delete this.items[this.head]
     // Increase the head index
     this.head++
-    // Return the element
-    return element
+    // Return the item
+    return item
   }
 
   peek () {
@@ -84,12 +84,12 @@ module.exports = class Queue {
     if (this.tail === this.head) {
       return undefined
     }
-    // Pick an element
-    return this.elements[this.head]
+    // Pick an item
+    return this.items[this.head]
   }
 
   size () {
-    return Object.keys(this.elements).length
+    return Object.keys(this.items).length
   }
 
   isEmpty () {

--- a/lib/Queue.js
+++ b/lib/Queue.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const { emitWarning } = require('process')
+
+/**
+ * @typedef {object} QueueOptions
+ * @prop {number} [maxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `Infinity`
+ * @prop {(any) => number?} [sizeCalculation] Function used to calculate the size of stored elements. Default: `element => element.length`.
+ */
+
+/**
+ * A linear data structure of a FIFO (First In - First Out) type.
+ *
+ * Inspired by:
+ * - https://vhudyma-blog.eu/implement-queue-in-javascript/
+ * - https://github.com/isaacs/node-lru-cache
+ */
+module.exports = class Queue {
+  /**
+   * @param {QueueOptions} opts
+   */
+  constructor (opts) {
+    // The actual queue
+    this.elements = {}
+    // The index of the head element
+    this.head = 0
+    // The index of the tail element
+    this.tail = 0
+    this.calculatedSize = 0
+    this.sizes = {}
+    this.opts = {
+      maxSize: Infinity,
+      sizeCalculation: (element) => element.length,
+      ...opts
+    }
+  }
+
+  enqueue (element) {
+    const index = this.tail
+    const size = this.opts.sizeCalculation(element)
+    if (size > this.opts.maxSize) {
+      emitWarning(`Unable to enqueue element because element size ${size} is greater than maxSize ${this.opts.maxSize}`)
+      return
+    }
+    this.sizes[index] = size
+    const maxSize = this.opts.maxSize - size
+    while (this.calculatedSize > maxSize) {
+      this.evict()
+    }
+    this.calculatedSize += size
+    // Add an element on the current tail index
+    this.elements[index] = element
+    // Increase the index of the tail element
+    // So the next elements are added at the end
+    this.tail++
+  }
+
+  evict () {
+    // If the queue is empty
+    if (this.tail === this.head) {
+      return undefined
+    }
+    const index = this.head
+    this.calculatedSize -= this.sizes[index]
+    delete this.sizes[index]
+    this.dequeue()
+  }
+
+  dequeue () {
+    const element = this.peek()
+    if (element === undefined) {
+      return element
+    }
+    // Delete it
+    delete this.elements[this.head]
+    // Increase the head index
+    this.head++
+    // Return the element
+    return element
+  }
+
+  peek () {
+    // If the queue is empty, return "undefined"
+    if (this.tail === this.head) {
+      return undefined
+    }
+    // Pick an element
+    return this.elements[this.head]
+  }
+
+  size () {
+    return Object.keys(this.elements).length
+  }
+
+  isEmpty () {
+    return this.size() === 0
+  }
+}

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -3,7 +3,6 @@
 const net = require('net')
 const tls = require('tls')
 const stream = require('stream')
-const { emitWarning } = require('process')
 const { Backoff, FibonacciStrategy } = require('backoff')
 const Queue = require('./Queue')
 
@@ -69,18 +68,15 @@ module.exports = function factory (userOptions) {
     autoDestroy: true,
     close () { socket.end() },
     write (data, encoding, callback) {
-      // check if the socket is writable otherwise an Error is thrown "This socket has been ended by the other party"
-      if (!socket.writableEnded) {
-        socket.write(data, encoding, (err) => {
-          if (err && options.recovery) {
+      socket.write(data, encoding, (err) => {
+        if (err) {
+          outputStream.emit('error', new Error(`unable to write data to the TCP socket: ${err.message}`))
+          if (options.recovery) {
             // unable to write data, will try later when the server becomes available again
             recoveryQueue.enqueue({ data, encoding })
           }
-        })
-      } else if (options.recovery) {
-        // unable to write data, will try later when the server becomes available again
-        recoveryQueue.enqueue({ data, encoding })
-      }
+        }
+      })
       callback()
     }
   })
@@ -134,18 +130,27 @@ module.exports = function factory (userOptions) {
         options.onSocketClose(socketError)
       }
     }
-    if (options.reconnect) reconnect()
+    if (options.reconnect) {
+      reconnect()
+    } else {
+      outputStream.emit('close', hadError)
+    }
   }
 
   function connectListener () {}
 
   function endListener () {
     disconnect()
-    if (options.reconnect) reconnect()
+    if (options.reconnect) {
+      reconnect()
+    } else {
+      outputStream.emit('end')
+    }
   }
 
   function errorListener (err) {
     socketError = err
+    outputStream.emit('error', socketError)
   }
   // end: connection listeners
 
@@ -172,7 +177,7 @@ module.exports = function factory (userOptions) {
     const item = recoveryQueue.peek()
     socket.write(item.data, item.encoding, (err) => {
       if (err) {
-        emitWarning('unable to recover data because an error occurred while writing data to the TCP socket', { detail: err.message })
+        outputStream.emit('error', new Error(`unable to write data to the TCP socket while recovering data: ${err.message}`))
         return
       }
       recoveryQueue.dequeue()
@@ -181,8 +186,7 @@ module.exports = function factory (userOptions) {
   }
 
   connect(() => {
-    // TODO we must propagate the events from the socket to the outputStream
-    outputStream.emit('open')
+    outputStream.emit('open', socket.address())
   })
 
   function createRetryBackoff () {

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -147,7 +147,7 @@ module.exports = function factory (userOptions) {
   function errorListener (err) {
     socketError = err
   }
-  // end: connection listerners
+  // end: connection listeners
 
   function addListeners () {
     socket

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -67,12 +67,18 @@ module.exports = function factory (userOptions) {
     autoDestroy: true,
     close () { socket.end() },
     write (data, encoding, callback) {
-      socket.write(data, encoding, (err) => {
-        if (err && options.recovery) {
-          // unable to write data, will try later when the server becomes available again
-          recoveryQueue.enqueue({ data, encoding })
-        }
-      })
+      // check if the socket is writable otherwise an Error is thrown "This socket has been ended by the other party"
+      if (!socket.writableEnded) {
+        socket.write(data, encoding, (err) => {
+          if (err && options.recovery) {
+            // unable to write data, will try later when the server becomes available again
+            recoveryQueue.enqueue({ data, encoding })
+          }
+        })
+      } else if (options.recovery) {
+        // unable to write data, will try later when the server becomes available again
+        recoveryQueue.enqueue({ data, encoding })
+      }
       callback()
     }
   })

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -4,6 +4,7 @@ const net = require('net')
 const tls = require('tls')
 const stream = require('stream')
 const { Backoff, FibonacciStrategy } = require('backoff')
+const Queue = require('./Queue')
 
 /**
  * @typedef {object} TcpConnectionOptions
@@ -17,6 +18,9 @@ const { Backoff, FibonacciStrategy } = require('backoff')
  * @prop {(error: Error|null) => void?} [onSocketClose] The callback when the socket is closed. Default: ``.
  * @prop {BackoffStrategy?} [backoffStrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
+ * @prop {boolean} [recovery] Enable recovering data when reconnecting after the connection was dropped. Default: `false`.
+ * @prop {({data: Buffer, encoding: string}) => number?} [recoveryQueueSizeCalculation] Function used to calculate the size of stored elements. Default: `element => element.data.length + element.encoding.length`.
+ * @prop {number?} [recoveryQueueMaxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `Infinity`
  */
 
 /**
@@ -35,7 +39,9 @@ module.exports = function factory (userOptions) {
       port: 514,
       reconnect: false,
       reconnectTries: Infinity,
-      onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message)
+      onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message),
+      recovery: false,
+      recoveryQueueSizeCalculation: (element) => element.data.length + element.encoding.length
     },
     userOptions
   )
@@ -49,6 +55,10 @@ module.exports = function factory (userOptions) {
   let connected = false
   let connecting = false
   let socketError = null
+  const recoveryQueue = new Queue({
+    maxSize: options.recoveryQueueMaxSize,
+    sizeCalculation: options.recoveryQueueSizeCalculation
+  })
 
   const retryBackoff = createRetryBackoff()
 
@@ -57,7 +67,12 @@ module.exports = function factory (userOptions) {
     autoDestroy: true,
     close () { socket.end() },
     write (data, encoding, callback) {
-      socket.write(data)
+      socket.write(data, encoding, (err) => {
+        if (err && options.recovery) {
+          // unable to write data, will try later when the server becomes available again
+          recoveryQueue.enqueue({ data, encoding })
+        }
+      })
       callback()
     }
   })
@@ -142,6 +157,21 @@ module.exports = function factory (userOptions) {
       .removeAllListeners('error')
   }
 
+  function recoverEnqueuedData () {
+    if (recoveryQueue.isEmpty()) {
+      return
+    }
+    const item = recoveryQueue.peek()
+    socket.write(item.data, item.encoding, (err) => {
+      if (err) {
+        // stop
+        return
+      }
+      recoveryQueue.dequeue()
+      recoverEnqueuedData()
+    })
+  }
+
   connect(() => {
     // TODO we must propagate the events from the socket to the outputStream
     outputStream.emit('open')
@@ -154,6 +184,9 @@ module.exports = function factory (userOptions) {
       connect((err) => {
         if (connected === false) {
           return retry.backoff(err)
+        }
+        if (options.recovery) {
+          recoverEnqueuedData()
         }
       })
     })

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -63,20 +63,30 @@ module.exports = function factory (userOptions) {
 
   const retryBackoff = createRetryBackoff()
 
-  // This stream is the one returned to psock.js.
+  function handleSocketWriteError (err, data, encoding) {
+    outputStream.emit('error', new Error(`unable to write data to the TCP socket: ${err.message}`))
+    if (options.recovery) {
+      // unable to write data, will try later when the server becomes available again
+      recoveryQueue.enqueue({ data, encoding })
+    }
+  }
+
+  // this stream is the one returned to psock.js.
   const outputStream = stream.Writable({
     autoDestroy: true,
     close () { socket.end() },
     write (data, encoding, callback) {
-      socket.write(data, encoding, (err) => {
-        if (err) {
-          outputStream.emit('error', new Error(`unable to write data to the TCP socket: ${err.message}`))
-          if (options.recovery) {
-            // unable to write data, will try later when the server becomes available again
-            recoveryQueue.enqueue({ data, encoding })
+      // node 14 throws an Error if the socket has ended (instead of calling the callback with an Error)
+      // remind: can be removed once we drop node 14!
+      if (socket.writableEnded) {
+        handleSocketWriteError(new Error('This socket has been ended by the other party'), data, encoding)
+      } else {
+        socket.write(data, encoding, (err) => {
+          if (err) {
+            handleSocketWriteError(err, data, encoding)
           }
-        }
-      })
+        })
+      }
       callback()
     }
   })

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -3,6 +3,7 @@
 const net = require('net')
 const tls = require('tls')
 const stream = require('stream')
+const { emitWarning } = require('process')
 const { Backoff, FibonacciStrategy } = require('backoff')
 const Queue = require('./Queue')
 
@@ -18,9 +19,9 @@ const Queue = require('./Queue')
  * @prop {(error: Error|null) => void?} [onSocketClose] The callback when the socket is closed. Default: ``.
  * @prop {BackoffStrategy?} [backoffStrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
- * @prop {boolean} [recovery] Enable recovering data when reconnecting after the connection was dropped. Default: `false`.
- * @prop {({data: Buffer, encoding: string}) => number?} [recoveryQueueSizeCalculation] Function used to calculate the size of stored elements. Default: `element => element.data.length + element.encoding.length`.
- * @prop {number?} [recoveryQueueMaxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `1024`
+ * @prop {boolean} [recovery] Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.
+ * @prop {({data: Buffer, encoding: string}) => number?} [recoveryQueueSizeCalculation] Function used to calculate the size of stored items. Default: `item => item.data.length + item.encoding.length`.
+ * @prop {number?} [recoveryQueueMaxSize] The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.
  */
 
 /**
@@ -42,7 +43,7 @@ module.exports = function factory (userOptions) {
       onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message),
       recovery: false,
       recoveryQueueMaxSize: 1024,
-      recoveryQueueSizeCalculation: (element) => element.data.length + element.encoding.length
+      recoveryQueueSizeCalculation: (item) => item.data.length + item.encoding.length
     },
     userOptions
   )
@@ -171,7 +172,7 @@ module.exports = function factory (userOptions) {
     const item = recoveryQueue.peek()
     socket.write(item.data, item.encoding, (err) => {
       if (err) {
-        // stop
+        emitWarning('unable to recover data because an error occurred while writing data to the TCP socket', { detail: err.message })
         return
       }
       recoveryQueue.dequeue()

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -20,7 +20,7 @@ const Queue = require('./Queue')
  * @prop {stream.Readable?} [sourceStream]
  * @prop {boolean} [recovery] Enable recovering data when reconnecting after the connection was dropped. Default: `false`.
  * @prop {({data: Buffer, encoding: string}) => number?} [recoveryQueueSizeCalculation] Function used to calculate the size of stored elements. Default: `element => element.data.length + element.encoding.length`.
- * @prop {number?} [recoveryQueueMaxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `Infinity`
+ * @prop {number?} [recoveryQueueMaxSize] Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `1024`
  */
 
 /**
@@ -41,6 +41,7 @@ module.exports = function factory (userOptions) {
       reconnectTries: Infinity,
       onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message),
       recovery: false,
+      recoveryQueueMaxSize: 1024,
       recoveryQueueSizeCalculation: (element) => element.data.length + element.encoding.length
     },
     userOptions

--- a/lib/UdpConnection.js
+++ b/lib/UdpConnection.js
@@ -35,12 +35,16 @@ module.exports = function factory (userOptions) {
     sourceStream.pipe(writableStream, { end: false })
   }
 
+  socket.on('close', () => {
+    writableStream.emit('close', false)
+  })
+
   socket.on('error', (err) => {
     writableStream.emit('error', err)
   })
 
   socket.connect(options.port, options.address, () => {
-    writableStream.emit('open')
+    writableStream.emit('open', socket.address())
   })
 
   return writableStream

--- a/lib/pino-transport.js
+++ b/lib/pino-transport.js
@@ -14,7 +14,9 @@ const defaultOptions = {
   noverify: false,
   reconnect: false,
   reconnectTries: Infinity,
-  settings: null
+  settings: null,
+  recovery: false,
+  recoveryQueueMaxSize: 1024
 }
 
 async function socketTransport (opts) {

--- a/psock.js
+++ b/psock.js
@@ -31,7 +31,9 @@ function cli () {
     echo: Boolean,
     help: Boolean,
     version: Boolean,
-    settings: String
+    settings: String,
+    recovery: Boolean,
+    'recovery-queue-max-size': Number
   }
   const shortOpts = {
     u: '--unixsocket',
@@ -75,6 +77,7 @@ function cli () {
   let connection
   if (options.mode === 'tcp') {
     connection = tcpConnectionFactory(options)
+    connection.on('error', (err) => console.error(err.message))
   } else {
     connection = udpConnectionFactory(options)
   }

--- a/psock.js
+++ b/psock.js
@@ -77,10 +77,11 @@ function cli () {
   let connection
   if (options.mode === 'tcp') {
     connection = tcpConnectionFactory(options)
-    connection.on('error', (err) => console.error(err.message))
   } else {
     connection = udpConnectionFactory(options)
   }
+
+  connection.on('error', (err) => console.error(err.message))
 
   function shutdown () {
     try {

--- a/test/queue.js
+++ b/test/queue.js
@@ -4,7 +4,7 @@
 const Queue = require('../lib/Queue')
 const { expect } = require('chai')
 
-test('#enqueue elements', function () {
+test('#enqueue items', function () {
   const q = new Queue()
   q.enqueue('1')
   q.enqueue('2')
@@ -80,12 +80,12 @@ test('#enqueue with max size should evict until the total size is below max size
   expect(q.dequeue()).to.eq('ghi')
 })
 
-test('#enqueue an element that exceeds max size', function (done) {
+test('#enqueue an item that exceeds max size', function (done) {
   const q = new Queue({
     maxSize: 2
   })
   process.on('warning', (event) => {
-    expect(event.message).to.eq('Unable to enqueue element because element size 3 is greater than maxSize 2')
+    expect(event.message).to.eq('unable to enqueue item because item size 3 is greater than maxSize 2')
     done()
   })
   q.enqueue('abc') // should emit a warning

--- a/test/queue.js
+++ b/test/queue.js
@@ -4,8 +4,6 @@
 const Queue = require('../lib/Queue')
 const { expect } = require('chai')
 
-suite('Queue')
-
 test('#enqueue elements', function () {
   const q = new Queue()
   q.enqueue('1')

--- a/test/queue.js
+++ b/test/queue.js
@@ -1,0 +1,96 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const Queue = require('../lib/Queue')
+const { expect } = require('chai')
+
+suite('Queue')
+
+test('#enqueue elements', function () {
+  const q = new Queue()
+  q.enqueue('1')
+  q.enqueue('2')
+  q.enqueue('3')
+  q.enqueue('4')
+  expect(q.size()).to.eq(4)
+  expect(q.dequeue()).to.eq('1')
+  expect(q.dequeue()).to.eq('2')
+  expect(q.dequeue()).to.eq('3')
+  expect(q.size()).to.eq(1)
+  expect(q.dequeue()).to.eq('4')
+  expect(q.size()).to.eq(0)
+  expect(q.dequeue()).to.eq(undefined) // empty
+  expect(q.size()).to.eq(0)
+})
+
+test('#dequeue non empty queue', function () {
+  const q = new Queue()
+  q.enqueue('1')
+  expect(q.dequeue()).to.eq('1')
+  q.enqueue('2')
+  expect(q.dequeue()).to.eq('2')
+  expect(q.dequeue()).to.eq(undefined) // empty
+  expect(q.size()).to.eq(0)
+})
+
+test('#dequeue empty queue', function () {
+  const q = new Queue()
+  expect(q.dequeue()).to.eq(undefined) // empty
+})
+
+test('#enqueue with max size should evict first in (same size)', function () {
+  const q = new Queue({
+    maxSize: 10
+  })
+  q.enqueue('a')
+  q.enqueue('bc')
+  q.enqueue('de')
+  q.enqueue('f')
+  q.enqueue('g')
+  q.enqueue('hij')
+  q.enqueue('k') // exceed max size, will dequeue 'a' to make space
+  expect(q.size()).to.eq(6)
+  expect(q.dequeue()).to.eq('bc')
+})
+
+test('#enqueue with max size should evict first in (different size)', function () {
+  const q = new Queue({
+    maxSize: 10
+  })
+  q.enqueue('abc')
+  q.enqueue('de')
+  q.enqueue('f')
+  q.enqueue('ghi')
+  q.enqueue('j')
+  q.enqueue('k')
+  q.enqueue('l') // exceed max size, will dequeue 'abc' to make space
+  expect(q.size()).to.eq(6)
+  expect(q.dequeue()).to.eq('de')
+})
+
+test('#enqueue with max size should evict until the total size is below max size', function () {
+  const q = new Queue({
+    maxSize: 10
+  })
+  q.enqueue('a')
+  q.enqueue('b')
+  q.enqueue('c')
+  q.enqueue('def')
+  q.enqueue('ghi')
+  q.enqueue('klmno') // exceed max size, will dequeue 'a', 'b', 'c' and 'def' to make space
+  expect(q.size()).to.eq(2)
+  expect(q.dequeue()).to.eq('ghi')
+})
+
+test('#enqueue an element that exceeds max size', function (done) {
+  const q = new Queue({
+    maxSize: 2
+  })
+  process.on('warning', (event) => {
+    expect(event.message).to.eq('Unable to enqueue element because element size 3 is greater than maxSize 2')
+    done()
+  })
+  q.enqueue('abc') // should emit a warning
+  expect(q.size()).to.eq(0)
+  expect(q.dequeue()).to.eq(undefined)
+})

--- a/test/recovery.js
+++ b/test/recovery.js
@@ -1,0 +1,97 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const TcpConnection = require('../lib/TcpConnection')
+const { expect } = require('chai')
+const net = require('net')
+
+function startServer ({ address, port, next }) {
+  const socket = net.createServer((connection) => {
+    connection.on('data', (data) => {
+      next({ action: 'data', data })
+      connection.destroy()
+    })
+  })
+
+  socket.listen(port || 0, address || '127.0.0.1', () => {
+    next({
+      action: 'started',
+      address: socket.address().address,
+      port: socket.address().port
+    })
+  })
+
+  return socket
+}
+
+test('recovery', function (done) {
+  let address
+  let port
+  let tcpConnection
+  let counter = 0
+  let closing = false
+  const received = []
+
+  function sendData () {
+    setInterval(() => {
+      counter++
+      tcpConnection.write(`log${counter}\n`, 'utf8')
+    }, 50)
+  }
+
+  function startSecondServer () {
+    const secondServer = startServer({
+      address,
+      port,
+      next: (msg) => {
+        switch (msg.action) {
+          case 'data':
+            received.push(msg)
+            if (!closing) {
+              closing = true
+              setTimeout(() => {
+                secondServer.close(() => {
+                  const logs = received
+                    .map(it => it.data.toString('utf8'))
+                    .reduce((previousValue, currentValue) => previousValue + currentValue)
+                    .split('\n')
+                    .filter(it => it !== '')
+                  const logNumbers = logs.map(it => parseInt(it.replace('log', '')))
+                  expect(logs.length).to.eq(logNumbers[logNumbers.length - 1])
+                  // make sure that no number is missing
+                  expect(logNumbers).to.deep.eq(Array.from({ length: logNumbers.length }, (_, i) => i + 1))
+                  done()
+                })
+              }, 200) // wait recovery a bit to make sure that enqueued data have been recovered
+            }
+            break
+        }
+      }
+    })
+  }
+
+  const firstServer = startServer({
+    next: (msg) => {
+      switch (msg.action) {
+        case 'started':
+          address = msg.address
+          port = msg.port
+          tcpConnection = TcpConnection({
+            address,
+            port,
+            reconnect: true,
+            recovery: true
+          })
+          sendData()
+          break
+        case 'data':
+          received.push(msg)
+          firstServer.close(() => {
+            // first server is closed
+            setTimeout(startSecondServer, 50)
+          })
+          break
+      }
+    }
+  })
+})

--- a/test/recovery.js
+++ b/test/recovery.js
@@ -84,6 +84,7 @@ test('recovery', function (done) {
             reconnect: true,
             recovery: true
           })
+          tcpConnection.on('error', () => { /* ignore */ })
           sendData()
           break
         case 'data':

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -26,4 +26,5 @@ test('tcp backoff', function testTcpBackoff (done) {
       }
     }
   })
+  tcpConnection.on('error', () => { /* ignore */ })
 })


### PR DESCRIPTION
Introduce a recovery queue in order to store data when the connection is lost and send them when the connection is established again.

New options:

- `recovery`: Enable recovering data when reconnecting after the connection was dropped. Default: `false`.
- `recoveryQueueSizeCalculation`: Function used to calculate the size of stored elements. Default: `element => element.data.length + element.encoding.length`.
- `recoveryQueueMaxSize`: Positive integer to track the sizes of items added to the cache, and automatically evict items in order to stay below this size. Default: `Infinity`

This feature is disabled by default.
Should we emit a warning if the user enables this feature without a max size?

Since I've updated the Readme.md in #71, I will add documentation for them once #71 is merged.

Resolves #72 

