### PR TITLE
resolves #73 emit open when reconnect and emit socketError instead of error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,11 +54,31 @@ pino(transport)
 
 ### Events
 
-| Name    | Callback Signature               | Description                                                                                                                                          |
-|---------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `open`  | `(address: AddressInfo) => void` | Emitted when the TCP or UDP connection is established.                                                                                               |
-| `error` | `(error: Error) => void`         | Emitted when an error occurs on the TCP or UDP socket.                                                                                               |
-| `close` | `(hadError: Boolean) => void`    | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
+| Name          | Callback Signature               | Description                                                                                                                                          |
+|---------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `open`        | `(address: AddressInfo) => void` | Emitted when the TCP or UDP connection is established.                                                                                               |
+| `socketError` | `(error: Error) => void`         | Emitted when an error occurs on the TCP or UDP socket. The socket won't be closed.                                                                   |
+| `close`       | `(hadError: Boolean) => void`    | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
+
+**IMPORTANT:** In version prior to 6.0, an `error` event was emitted on the writable stream when an error occurs on the TCP or UDP socket.
+In other words, it was not possible to write data to the writable stream after an error occurs on the TCP or UDP socket.
+If you want to restore the previous behavior you can do:
+
+```js
+transport.on('socketError', () => {
+  transport.end()
+})
+```
+
+Alternatively, you can propagate the socket error using:
+
+```js
+transport.on('socketError', (err) => {
+  transport.emit('error', err)
+})
+```
+
+In this case, make sure that you are listening to the `error` event otherwise you will get an `Uncaught Error`.
 
 ## Usage as Pino Legacy Transport
 

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -64,7 +64,7 @@ module.exports = function factory (userOptions) {
   const retryBackoff = createRetryBackoff()
 
   function handleSocketWriteError (err, data, encoding) {
-    outputStream.emit('error', new Error(`unable to write data to the TCP socket: ${err.message}`))
+    outputStream.emit('socketError', new Error(`unable to write data to the TCP socket: ${err.message}`))
     if (options.recovery) {
       // unable to write data, will try later when the server becomes available again
       recoveryQueue.enqueue({ data, encoding })
@@ -163,7 +163,9 @@ module.exports = function factory (userOptions) {
 
   function errorListener (err) {
     socketError = err
-    outputStream.emit('error', socketError)
+    // error might be recoverable (i.e., reconnect or intermittent failure)
+    // we should not emit an 'error' otherwise the stream will be closed, and we won't be able to write to it
+    outputStream.emit('socketError', socketError)
   }
   // end: connection listeners
 
@@ -190,7 +192,7 @@ module.exports = function factory (userOptions) {
     const item = recoveryQueue.peek()
     socket.write(item.data, item.encoding, (err) => {
       if (err) {
-        outputStream.emit('error', new Error(`unable to write data to the TCP socket while recovering data: ${err.message}`))
+        outputStream.emit('socketError', new Error(`unable to write data to the TCP socket while recovering data: ${err.message}`))
         return
       }
       recoveryQueue.dequeue()
@@ -210,6 +212,7 @@ module.exports = function factory (userOptions) {
         if (connected === false) {
           return retry.backoff(err)
         }
+        outputStream.emit('open', socket.address())
         if (options.recovery) {
           recoverEnqueuedData()
         }

--- a/lib/UdpConnection.js
+++ b/lib/UdpConnection.js
@@ -40,7 +40,7 @@ module.exports = function factory (userOptions) {
   })
 
   socket.on('error', (err) => {
-    writableStream.emit('error', err)
+    writableStream.emit('socketError', err)
   })
 
   socket.connect(options.port, options.address, () => {

--- a/psock.js
+++ b/psock.js
@@ -81,7 +81,7 @@ function cli () {
     connection = udpConnectionFactory(options)
   }
 
-  connection.on('error', (err) => console.error(err.message))
+  connection.on('socketError', (err) => console.error(err.message))
 
   function shutdown () {
     try {

--- a/test/recovery.js
+++ b/test/recovery.js
@@ -84,7 +84,6 @@ test('recovery', function (done) {
             reconnect: true,
             recovery: true
           })
-          tcpConnection.on('error', () => { /* ignore */ })
           sendData()
           break
         case 'data':

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -26,5 +26,4 @@ test('tcp backoff', function testTcpBackoff (done) {
       }
     }
   })
-  tcpConnection.on('error', () => { /* ignore */ })
 })

--- a/test/tcpReconnect.js
+++ b/test/tcpReconnect.js
@@ -91,6 +91,7 @@ test('tcp reconnect', function testTcpReconnect (done) {
 
 test('tcp reconnect after initial failure', async function testTcpReconnectAfterInitialFailure () {
   let failureCount = 0
+  let openCount = 0
   let counter = 0
   function sendData () {
     setInterval(() => {
@@ -105,7 +106,8 @@ test('tcp reconnect after initial failure', async function testTcpReconnectAfter
     port,
     reconnect: true
   })
-  tcpConnection.on('error', () => { failureCount++ })
+  tcpConnection.on('open', () => { openCount++ })
+  tcpConnection.on('socketError', () => { failureCount++ })
   sendData()
   const received = await new Promise((resolve, reject) => {
     let closing = false
@@ -127,6 +129,7 @@ test('tcp reconnect after initial failure', async function testTcpReconnectAfter
       }
     })
   })
+  expect(openCount).to.eq(1)
   expect(failureCount).to.gte(counter)
   expect(received.length).to.eq(1)
   expect(received[0].data.toString('utf8')).to.eq(`log${counter}\n`)

--- a/test/tcpSocketError.js
+++ b/test/tcpSocketError.js
@@ -1,0 +1,48 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const TcpConnection = require('../lib/TcpConnection')
+const { expect } = require('chai')
+
+test('close connection', function (done) {
+  const tcpConnection = TcpConnection({
+    address: '127.0.0.1',
+    port: 65535,
+    reconnect: false
+  })
+  tcpConnection.on('socketError', () => {
+    tcpConnection.end()
+  })
+  tcpConnection.on('finish', () => {
+    process.nextTick(() => {
+      expect(tcpConnection.destroyed).to.eq(true)
+      tcpConnection.write('test', 'utf8', (err) => {
+        // cannot write
+        expect(err.message).to.eq('write after end')
+        done()
+      })
+    })
+  })
+})
+
+test('retry connection', function (done) {
+  const tcpConnection = TcpConnection({
+    address: '127.0.0.1',
+    port: 65535,
+    reconnect: false
+  })
+  let counter = 0
+  setInterval(() => {
+    counter++
+    tcpConnection.write(`log${counter}\n`, 'utf8', () => { /* ignore */ })
+  }, 100)
+  tcpConnection.on('socketError', () => {
+    // TCP connection is still writable
+    expect(tcpConnection.writableEnded).to.eq(false)
+    if (counter === 2) {
+      tcpConnection.end(() => {
+        done()
+      })
+    }
+  })
+})


### PR DESCRIPTION
Follow-up of #76 

I will rebase on master once #76 is merged and add a unit test to make sure that `open` is emitted on reconnect and that `socketError` is emitted when an error occurs on the TCP or UDP socket.

This is potentially a breaking change since previously the UDP socket emitted an `error` event. The new behavior is more friendly since it won't close/end the stream. Please note that it's still possible to obtain the previous behavior using:

```js
stream.on('socketError', (err) => stream.destroy(err))
// or
stream.on('socketError', (err) => stream.emit('error', err))
```