### PR TITLE
Emit a reconnectFailure event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,11 +54,12 @@ pino(transport)
 
 ### Events
 
-| Name          | Callback Signature               | Description                                                                                                                                          |
-|---------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `open`        | `(address: AddressInfo) => void` | Emitted when the TCP or UDP connection is established.                                                                                               |
-| `socketError` | `(error: Error) => void`         | Emitted when an error occurs on the TCP or UDP socket. The socket won't be closed.                                                                   |
-| `close`       | `(hadError: Boolean) => void`    | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
+| Name               | Callback Signature                      | Description                                                                                                                                          |
+|--------------------|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `open`             | `(address: AddressInfo) => void`        | Emitted when the TCP or UDP connection is established.                                                                                               |
+| `socketError`      | `(error: Error) => void`                | Emitted when an error occurs on the TCP or UDP socket. The socket won't be closed.                                                                   |
+| `close`            | `(hadError: Boolean) => void`           | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
+| `reconnectFailure` | `(error: Error&#124;undefined) => void` | Emitted when the maximum number of backoffs (i.e., reconnect tries) is reached on a TCP connection.                                                  |
 
 **IMPORTANT:** In version prior to 6.0, an `error` event was emitted on the writable stream when an error occurs on the TCP or UDP socket.
 In other words, it was not possible to write data to the writable stream after an error occurs on the TCP or UDP socket.

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -130,8 +130,8 @@ module.exports = function factory (userOptions) {
     }
   }
 
-  function reconnect () {
-    retryBackoff.backoff()
+  function reconnect (err) {
+    retryBackoff.backoff(err)
   }
   // end: connection handlers
 
@@ -144,7 +144,7 @@ module.exports = function factory (userOptions) {
       }
     }
     if (options.reconnect) {
-      reconnect()
+      reconnect(hadError && socketError)
     } else {
       outputStream.emit('close', hadError)
     }
@@ -218,7 +218,7 @@ module.exports = function factory (userOptions) {
         }
       })
     })
-    retry.on('fail', (err) => process.stderr.write(`could not reconnect: ${err.message}`))
+    retry.on('fail', (err) => outputStream.emit('reconnectFailure', err))
     return retry
   }
 

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -143,8 +143,8 @@ module.exports = function factory (userOptions) {
         options.onSocketClose(socketError)
       }
     }
-    if (options.reconnect) {
-      reconnect(hadError && socketError)
+    if (options.reconnect && hadError) {
+      reconnect(socketError)
     } else {
       outputStream.emit('close', hadError)
     }

--- a/test/recovery.js
+++ b/test/recovery.js
@@ -62,7 +62,9 @@ test('recovery', function (done) {
                   // make sure that no number is missing
                   expect(logNumbers).to.deep.eq(Array.from({ length: logNumbers.length }, (_, i) => i + 1))
                 } finally {
-                  done()
+                  tcpConnection.end(() => {
+                    done()
+                  })
                 }
               })
             }

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -22,7 +22,7 @@ test('tcp backoff', function testTcpBackoff (done) {
         const nextBackoffDelay = exponentialStrategy.next()
         // initial, 10, 100... next delay should be 1000
         expect(nextBackoffDelay).to.eq(1000)
-        tcpConnection.end('', 'utf8', () => done())
+        tcpConnection.end(() => done())
       }
     }
   })

--- a/test/tcpRetyFail.js
+++ b/test/tcpRetyFail.js
@@ -19,6 +19,8 @@ test('tcp retry fail', function testTcpRetryFail (done) {
   tcpConnection.on('reconnectFailure', (lastError) => {
     expect(socketErrorCount).to.eq(3)
     expect(lastError).to.be.an('error')
-    done()
+    tcpConnection.end(() => {
+      done()
+    })
   })
 })

--- a/test/tcpRetyFail.js
+++ b/test/tcpRetyFail.js
@@ -1,0 +1,24 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const { expect } = require('chai')
+const TcpConnection = require('../lib/TcpConnection')
+
+test('tcp retry fail', function testTcpRetryFail (done) {
+  let socketErrorCount = 0
+  const tcpConnection = TcpConnection({
+    address: '127.0.0.1',
+    port: 0,
+    reconnect: true,
+    reconnectTries: 2
+  }
+  )
+  tcpConnection.on('socketError', () => {
+    socketErrorCount++
+  })
+  tcpConnection.on('reconnectFailure', (lastError) => {
+    expect(socketErrorCount).to.eq(3)
+    expect(lastError).to.be.an('error')
+    done()
+  })
+})

--- a/test/tcpSocketError.js
+++ b/test/tcpSocketError.js
@@ -19,7 +19,9 @@ test('close connection', function (done) {
       tcpConnection.write('test', 'utf8', (err) => {
         // cannot write
         expect(err.message).to.eq('write after end')
-        done()
+        tcpConnection.end(() => {
+          done()
+        })
       })
     })
   })
@@ -40,9 +42,7 @@ test('retry connection', function (done) {
     // TCP connection is still writable
     expect(tcpConnection.writableEnded).to.eq(false)
     if (counter === 2) {
-      tcpConnection.end(() => {
-        done()
-      })
+      tcpConnection.end(() => done())
     }
   })
 })


### PR DESCRIPTION
`err` can be undefined on fail event when `retryBackoff.backoff` is called without an error object:

```
TypeError: Cannot read properties of undefined (reading 'message')
    at Backoff.<anonymous> (/path/to/project/node_modules/pino-socket/lib/TcpConnection.js:221:100)
    at Backoff.emit (node:events:520:28)
    at Backoff.backoff (/path/to/project/node_modules/backoff/lib/backoff.js:42:14)
    at reconnect (/path/to/project/node_modules/pino-socket/lib/TcpConnection.js:134:18)
    at Socket.closeListener (/path/to/project/node_modules/pino-socket/lib/TcpConnection.js:147:7)
    at Socket.emit (node:events:520:28)
    at TCP.<anonymous> (node:net:687:12)
```