### PR TITLE
replace onSocketClose by emitting an event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,6 @@ pino(transport)
 | `noverify`                     | Allow connection to server with self-signed certificates. Default: false.                                                                                                                                                     |
 | `reconnect`                    | Enable reconnecting to dropped TCP destinations. Default: false.                                                                                                                                                              |
 | `reconnectTries`               | Number of times to attempt reconnection before giving up. Default: `Infinity`.                                                                                                                                                |
-| `onSocketClose`                | The callback when the socket is closed on TCP destinations. Default: `(socketError) => socketError && process.stderr.write(socketError.message)`.                                                                             |
 | `backoffStrategy`              | The backoff strategy to use on TCP destinations. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.                                                                     |
 | `recovery`                     | Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.                                     |
 | `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.                                                                                 |
@@ -54,12 +53,13 @@ pino(transport)
 
 ### Events
 
-| Name               | Callback Signature                      | Description                                                                                                                                          |
-|--------------------|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `open`             | `(address: AddressInfo) => void`        | Emitted when the TCP or UDP connection is established.                                                                                               |
-| `socketError`      | `(error: Error) => void`                | Emitted when an error occurs on the TCP or UDP socket. The socket won't be closed.                                                                   |
-| `close`            | `(hadError: Boolean) => void`           | Emitted after the TCP or UDP socket is closed. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
-| `reconnectFailure` | `(error: Error&#124;undefined) => void` | Emitted when the maximum number of backoffs (i.e., reconnect tries) is reached on a TCP connection.                                                  |
+| Name               | Callback Signature                      | Description                                                                                                                                                              |
+|--------------------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `open`             | `(address: AddressInfo) => void`        | Emitted when the TCP or UDP connection is established.                                                                                                                   |
+| `socketError`      | `(error: Error) => void`                | Emitted when an error occurs on the TCP or UDP socket. The socket won't be closed.                                                                                       |
+| `socketClose`      | `(error: Error&#124;null) => void`      | Emitted after the TCP socket is closed. The argument `error` is defined if the socket was closed due to a transmission error.                                            |
+| `close`            | `(hadError: Boolean) => void`           | Emitted after the TCP or UDP socket is closed and won't reconnect. The argument `hadError` is a boolean which says if the socket was closed due to a transmission error. |
+| `reconnectFailure` | `(error: Error&#124;undefined) => void` | Emitted when the maximum number of backoffs (i.e., reconnect tries) is reached on a TCP connection.                                                                      |
 
 **IMPORTANT:** In version prior to 6.0, an `error` event was emitted on the writable stream when an error occurs on the TCP or UDP socket.
 In other words, it was not possible to write data to the writable stream after an error occurs on the TCP or UDP socket.

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -15,7 +15,6 @@ const Queue = require('./Queue')
  * @prop {boolean} [reconnect] Enable reconnecting to dropped TCP destinations. Default: false.
  * @prop {number} [reconnectTries] Number of times to attempt reconnection before giving up. Default: `Infinity`
  * @prop {string?} [unixsocket] The unix socket path for the destination. Default: ``.
- * @prop {(error: Error|null) => void?} [onSocketClose] The callback when the socket is closed. Default: ``.
  * @prop {BackoffStrategy?} [backoffStrategy] The backoff strategy to use. The backoff strategy must implement the `BackoffStrategy` interface. Default: `new FibonacciStrategy()`.
  * @prop {stream.Readable?} [sourceStream]
  * @prop {boolean} [recovery] Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.
@@ -39,7 +38,6 @@ module.exports = function factory (userOptions) {
       port: 514,
       reconnect: false,
       reconnectTries: Infinity,
-      onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message),
       recovery: false,
       recoveryQueueMaxSize: 1024,
       recoveryQueueSizeCalculation: (item) => item.data.length + item.encoding.length
@@ -138,11 +136,7 @@ module.exports = function factory (userOptions) {
   // begin: connection listeners
   function closeListener (hadError) {
     disconnect()
-    if (hadError) {
-      if (options.onSocketClose) {
-        options.onSocketClose(socketError)
-      }
-    }
+    outputStream.emit('socketClose', hadError ? socketError : null)
     if (options.reconnect && hadError) {
       reconnect(socketError)
     } else {

--- a/test/tcpBackoff.js
+++ b/test/tcpBackoff.js
@@ -15,15 +15,15 @@ test('tcp backoff', function testTcpBackoff (done) {
     address: '127.0.0.1',
     port: 0,
     reconnect: true,
-    backoffStrategy: exponentialStrategy,
-    onSocketClose: () => {
-      closeCount++
-      if (closeCount === 3) {
-        const nextBackoffDelay = exponentialStrategy.next()
-        // initial, 10, 100... next delay should be 1000
-        expect(nextBackoffDelay).to.eq(1000)
-        tcpConnection.end(() => done())
-      }
+    backoffStrategy: exponentialStrategy
+  })
+  tcpConnection.on('socketClose', () => {
+    closeCount++
+    if (closeCount === 3) {
+      const nextBackoffDelay = exponentialStrategy.next()
+      // initial, 10, 100... next delay should be 1000
+      expect(nextBackoffDelay).to.eq(1000)
+      tcpConnection.end(() => done())
     }
   })
 })

--- a/test/tcpReconnect.js
+++ b/test/tcpReconnect.js
@@ -92,6 +92,7 @@ test('tcp reconnect', function testTcpReconnect (done) {
 test('tcp reconnect after initial failure', async function testTcpReconnectAfterInitialFailure () {
   let failureCount = 0
   let openCount = 0
+  let closeCount = 0
   let counter = 0
   function sendData () {
     setInterval(() => {
@@ -108,6 +109,7 @@ test('tcp reconnect after initial failure', async function testTcpReconnectAfter
   })
   tcpConnection.on('open', () => { openCount++ })
   tcpConnection.on('socketError', () => { failureCount++ })
+  tcpConnection.on('socketClose', () => { closeCount++ })
   sendData()
   const received = await new Promise((resolve, reject) => {
     let closing = false
@@ -129,6 +131,7 @@ test('tcp reconnect after initial failure', async function testTcpReconnectAfter
       }
     })
   })
+  expect(closeCount).to.eq(1)
   expect(openCount).to.eq(1)
   expect(failureCount).to.gte(counter)
   expect(received.length).to.eq(1)


### PR DESCRIPTION
I think we can remove `onSocketClose`. I introduced this option to preserve `process.stderr.write(socketError.message)` but in my opinion users should decide what they want to do.

I can add a note in the documentation to restore the previous behavior:

```js
stream.on('socketClose', (socketError) => socketError && process.stderr.write(socketError.message))
```