### PR TITLE
resolves #85 introduce onBeforeDataWrite callback

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,7 @@ pino(transport)
 | `recovery`                     | Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.                                     |
 | `recoveryQueueMaxSize`         | The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.                                                                                 |
 | `recoveryQueueSizeCalculation` | Function used to calculate the size of stored items. The item is passed as the first argument and contains a `data` (Buffer) and `encoding` (String) attribute. Default: `(item) => item.data.length + item.encoding.length`. |
+| `onBeforeDataWrite`            | Function used to manipulate TCP data before being written to the socket. Operations preformed here must be synchronous. Format: `(data) => Buffer`. Default: `null`                                                           |
 
 ### Events
 

--- a/lib/TcpConnection.js
+++ b/lib/TcpConnection.js
@@ -21,6 +21,7 @@ const Queue = require('./Queue')
  * @prop {boolean} [recovery] Enable a recovery mode when the TCP connection is lost which store data in a memory queue (FIFO) until the queue max size is reached or the TCP connection is restored. Default: `false`.
  * @prop {({data: Buffer, encoding: string}) => number?} [recoveryQueueSizeCalculation] Function used to calculate the size of stored items. Default: `item => item.data.length + item.encoding.length`.
  * @prop {number?} [recoveryQueueMaxSize] The maximum size of items added to the queue. When reached, oldest items "First In" will be evicted to stay below this size. Default: `1024`.
+ * @prop {(data: Buffer) => Buffer?} [onBeforeDataWrite] Function to manipulate the data before it written. Operations preformed here must be synchronous.
  */
 
 /**
@@ -42,7 +43,8 @@ module.exports = function factory (userOptions) {
       onSocketClose: (socketError) => socketError && process.stderr.write(socketError.message),
       recovery: false,
       recoveryQueueMaxSize: 1024,
-      recoveryQueueSizeCalculation: (item) => item.data.length + item.encoding.length
+      recoveryQueueSizeCalculation: (item) => item.data.length + item.encoding.length,
+      onBeforeDataWrite: null
     },
     userOptions
   )
@@ -84,6 +86,10 @@ module.exports = function factory (userOptions) {
       if (socket.writableEnded) {
         handleSocketWriteError(new Error('This socket has been ended by the other party'), data, encoding)
       } else {
+        if (typeof options.onBeforeDataWrite === 'function') {
+          data = options.onBeforeDataWrite(data)
+        }
+
         socket.write(data, encoding, (err) => {
           if (err) {
             handleSocketWriteError(err, data, encoding)

--- a/lib/pino-transport.js
+++ b/lib/pino-transport.js
@@ -16,7 +16,8 @@ const defaultOptions = {
   reconnectTries: Infinity,
   settings: null,
   recovery: false,
-  recoveryQueueMaxSize: 1024
+  recoveryQueueMaxSize: 1024,
+  onBeforeDataWrite: null
 }
 
 async function socketTransport (opts) {

--- a/test/tcpBeforeDataWrite.js
+++ b/test/tcpBeforeDataWrite.js
@@ -1,0 +1,63 @@
+'use strict'
+/* eslint-env node, mocha */
+
+const net = require('net')
+const TcpConnection = require('../lib/TcpConnection')
+const expect = require('chai').expect
+
+function startServer ({ address, port, next }) {
+  const socket = net.createServer((connection) => {
+    connection.on('data', (data) => {
+      next({ action: 'data', data })
+      connection.destroy()
+    })
+  })
+
+  socket.listen(port || 0, address || '127.0.0.1', () => {
+    next({
+      action: 'started',
+      address: socket.address().address,
+      port: socket.address().port
+    })
+  })
+
+  return socket
+}
+
+test('tcp beforeDataWrite', function testTcpBeforeDataWrite (done) {
+  let tcpConnection
+  function connect (address, port) {
+    tcpConnection = TcpConnection({
+      address,
+      port,
+      onBeforeDataWrite: (data) => {
+        expect(data.toString()).to.eq('log1\n')
+        return Buffer.from('log2\n', 'utf8')
+      }
+    })
+    tcpConnection.on('error', (err) => { console.log({ err })/* ignore */ })
+    tcpConnection.write('log1\n', 'utf8', () => {
+    })
+  }
+
+  let msgCount = 0
+  const server = startServer({ next })
+  function next (msg) {
+    switch (msg.action) {
+      case 'started':
+        connect(msg.address, msg.port)
+        break
+      case 'data':
+        msgCount += 1
+        tcpConnection.end(() => {
+          process.nextTick(() => {
+            expect(msg.data.toString()).to.eq('log2\n')
+            expect(msgCount).to.eq(1)
+            server.close(() => {
+              done()
+            })
+          })
+        })
+    }
+  }
+})


### PR DESCRIPTION
I'm introducing a callback called `onBeforeDataWrite` with a signature `(data: Buffer) => Buffer` that allows manipulation of the data before it is written out to the socket.

This resolves #85.